### PR TITLE
Update of cosine-error documentation on Read The Docs

### DIFF
--- a/HierarchBayesParcel/evaluation.py
+++ b/HierarchBayesParcel/evaluation.py
@@ -239,15 +239,15 @@ def u_prederr(U, uhat, expectation=True):
         return pt.count_nonzero(pt.abs(U-uhat))/U.numel()
 
 
-def coserr(Y, V, U, adjusted=False, soft_assign=True):
+def coserr(Y, V, U, adjusted=False, ):
     """Compute the cosine distance between the data to the predicted V's
 
     Args:
         Y: the test data, with a shape (num_sub, N, P)
         V: the predicted mean directions
         U: the predicted U's from the trained emission model (in multinomial notation)
-        adjusted: Adjusted for the length of the data vector?
-        soft_assign: Compute the expected mean cosine error if True; Otherwise, False
+        adjusted: Adjusted for the length of the data vector (see ) 
+        type: Compute the expected mean cosine error if True; Otherwise, False
     Returns:
         the averaged expected cosine distance. 0 indicates the same direction;
         1 - orthogonal; 2 - opposite direction

--- a/docs/source/atlas_training_example.ipynb
+++ b/docs/source/atlas_training_example.ipynb
@@ -238,7 +238,7 @@
     "K=10\n",
     "\n",
     "# Build spatial arrangement model\n",
-    "ar_model = ar.ArrangeIndependent(K, atlas.P, spatial_specific=True, \n",
+    "ar_model = ar.ArrangeIndependent(K, atlas.P, spatial_specific=True,\n",
     "                                 remove_redundancy=False)\n",
     "\n",
     "# Build emission models for each dataset\n",
@@ -283,10 +283,10 @@
    "source": [
     "M.initialize([data_mdtb, data_hcp], subj_ind='separate')\n",
     "# Since we use spatial independent model, here we will use EM training\n",
-    "# with 50 random initializations.  \n",
+    "# with 50 random initializations.\n",
     "M_fused, ll, _, U_indiv_fuse, _ = M.fit_em_ninits(iter=200, tol=0.01, fit_arrangement=True,\n",
     "                                                  fit_emission=True, init_arrangement=True,\n",
-    "                                                  init_emission=True, n_inits=50, first_iter=30, \n",
+    "                                                  init_emission=True, n_inits=50, first_iter=30,\n",
     "                                                  verbose=False)"
    ]
   },
@@ -381,7 +381,7 @@
     "M1.initialize([data_mdtb])\n",
     "M1, ll, theta, U_hat, _ = M1.fit_em_ninits(iter=200, tol=0.01, fit_arrangement=True,\n",
     "                                           fit_emission=True, init_arrangement=True,\n",
-    "                                           init_emission=True, n_inits=50, first_iter=30, \n",
+    "                                           init_emission=True, n_inits=50, first_iter=30,\n",
     "                                           verbose=False)\n",
     "\n",
     "# Train HCP parcellation only\n",
@@ -389,7 +389,7 @@
     "M2.initialize([data_hcp])\n",
     "M2, ll, theta, U_hat, _ = M2.fit_em_ninits(iter=200, tol=0.01, fit_arrangement=True,\n",
     "                                           fit_emission=True, init_arrangement=True,\n",
-    "                                           init_emission=True, n_inits=50, first_iter=30, \n",
+    "                                           init_emission=True, n_inits=50, first_iter=30,\n",
     "                                           verbose=False)\n"
    ]
   },
@@ -534,15 +534,6 @@
     "In practice, we highly recommend repeating this process a large number of times, until the solution with the highest fnal likelihood was found at least 10 times in independent learning runs. This increases our confidence that we had found a solution that may constitute a global maximum (but of course it is no guarantee for it).\n",
     "\n",
     "Please find [this example](https://github.com/DiedrichsenLab/FusionModel/blob/main/learn_fusion_gpu.py) for more details."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## GPU acceleration\n",
-    "\n",
-    "It is strongly recommended to use GPU to train the group atlas, which dramatically speeds up the training time. All code was written in python and native PyTorch that can be easily deployed on GPU. "
    ]
   }
  ],

--- a/docs/source/math.rst
+++ b/docs/source/math.rst
@@ -517,8 +517,8 @@ Comparing the true :math:`\mathbf{U}` and the inferred :math:`\hat{\mathbf{U}}`
 
 Note that these criteria only have value for simulations, for which we have the true parcellation :math:`\mathbf{U}`.
 
-1. The absolute error between :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`
-*****************************************************************************
+The absolute error between :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`
+**************************************************************************
 
 The first evaluation criterion is to calculate the absolute error between the true parcellation :math:`\mathbf{U}` and the expected :math:`\mathbf{\hat{U}}` which inferred on the training data. It defined as,
 
@@ -531,8 +531,8 @@ Note, this calculation of the mean absolute error is subject to the premutation 
 
 
 
-2. Normalized Mutual information (NMI) between :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`
-**********************************************************************************************
+Normalized Mutual information (NMI) between :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`
+*******************************************************************************************
 
 The second criteria is the normalized mutual information which examine the actual amount of "mutual information" between two parcellations :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`.  A NMI value closes to 0 indicate two parcellations are largely independent, while values close to 1 indicate significant agreement. It defined as:
 
@@ -545,8 +545,8 @@ Similarly, the :math:`||\mathbf{u}=i|\cap|\mathbf{\hat{u}}=j||` means the total 
 
 
 
-3. Adjusted rand index (ARI) between :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`
-************************************************************************************
+Adjusted rand index (ARI) between :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`
+*********************************************************************************
 
 The third one is the commonly used adjust rand index to test how similar the two given parcellations are. It defined as:
 
@@ -561,14 +561,14 @@ Intuitively, :math:`M_{00}` and :math:`M_{11}` account for the agreement of parc
 Prediction error on independent test data (:math:`\mathbf{Y}_{test}`)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-One way to evaluate parcellation models is to test how well they can predict new test data. In general we have test data :math:`\mathbf{Y}_{test}`, a :math:`N \times P` matrix with *N* measurements (tasks, timepoints) and *P* brain locations (voxels, vertices) for each subject. Therefore, :math:`\mathbf{y}_{i}` is the response profile (a N-long vector) for each brain location :math:`i`. 
+One way to evaluate parcellation models is to test how well they can predict new test data. In general we have test data :math:`\mathbf{Y}_{test}`, a :math:`N \times P` matrix with *N* measurements (tasks, timepoints) and *P* brain locations (voxels, vertices) for each subject. Therefore, :math:`\mathbf{y}_{i}` is the response profile (a N-long vector) for each brain location :math:`i`.
 
-Because fMRI data (task activities or time series) have very different signal to noise levels across different voxels and subjects (and because the model does not necessarily predict the amplitude of responses), a natural evaluation criterion is the cosine error between predicted and observed data. 
+Because fMRI data (task activities or time series) have very different signal to noise levels across different voxels and subjects (and because the model does not necessarily predict the amplitude of responses), a natural evaluation criterion is the cosine error between predicted and observed data.
 
 .. math::
 	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P \left( 1-\frac{\hat{\mathbf{y}}_{i}^{T}\mathbf{y}_i}{||\hat{\mathbf{y}}_i||||\mathbf{y}_i||} \right)
 
-For deriving a prediction from a probabilistic parcellation model, we have three options: 
+For deriving a prediction from a probabilistic parcellation model, we have three options:
 
 Cosine error using a hard parcellation
 **************************************
@@ -581,14 +581,14 @@ A simple evaluation is to set the prediction of the model to the response profil
 Cosine Error for the average prediction
 ***************************************
 
-Alternatively, we can set the prediction to the average of the response profiles across all the parcels, weighted by the probability that the voxels belongs to that parcel: 
+Alternatively, we can set the prediction to the average of the response profiles across all the parcels, weighted by the probability that the voxels belongs to that parcel:
 
 .. math::
 	\hat{\mathbf{y}}_{i} = \sum_k \hat{u}_i^{(k)}\mathbf{v}_k
 
-where :math:`\hat{u}_i^{(k)}` is a probability that brain location *i* belongs to parcel *k*. This probabilistic parcellation should of course be estimated on independent training data.  
+where :math:`\hat{u}_i^{(k)}` is a probability that brain location *i* belongs to parcel *k*. This probabilistic parcellation should of course be estimated on independent training data.
 
-The entire cosine error is then: 
+The entire cosine error is then:
 
 .. math::
 	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P \left( 1-\frac{ \left( \sum_k \hat{u}_i^{(k)}\mathbf{v}_k \right)^{T}\mathbf{y}_i}{|| \sum_k \hat{u}_i^{(k)}\mathbf{v}_k||\:||\mathbf{y}_i||} \right)
@@ -596,7 +596,7 @@ The entire cosine error is then:
 Expected cosine error
 *********************
 
-Rather than calculating the **cosine error for the average prediction** of the probabilistic model, we can also compute the **average cosine error across all possible predictions**. The expected cosine error is defined as: 
+Rather than calculating the **cosine error for the average prediction** of the probabilistic model, we can also compute the **average cosine error across all possible predictions**. The expected cosine error is defined as:
 
 .. math::
 	\begin{align*}
@@ -604,12 +604,12 @@ Rather than calculating the **cosine error for the average prediction** of the p
 	&= \frac{1}{P}\sum_i \sum_k \hat{u}_i^{(k)} \left( 1-{\mathbf{v}_k}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||} \right)
 	\end{align*}
 
-When we compare the first expression of the expected cosine error with the expression of the cosine error for the average prediction, we conclude that the prediction term is normalized to unit length 
-for the former (i.e. for each voxel :math:`i`, the sum across :math:`k` parcels is 1) whereas that is not the case for the latter.
+When we compare the second line for the expected cosine error with the expression for cosine error for the average prediction, we see that the prediction term is normalized to unit length
+for the former (i.e. for each voxel :math:`i`, the sum across :math:`N` observations is 1) whereas that is not the case for the latter.
 
 
 Adjusted vs. non-adjusted cosine error
-************************************** 
+**************************************
 
 For all three types of cosine error mentioned so far, a possible problem is that a voxel which has very little signal count as much as a voxel with a lot of signal. To address this, we can change how we average the cosine error across different voxels. An interesting choice is to weight each error by the squared length of the data vector:
 
@@ -619,7 +619,7 @@ For all three types of cosine error mentioned so far, a possible problem is that
 	&= \frac{1}{\sum_i^P ||\mathbf{y}_i||^2} \sum_i^P  \left( ||\mathbf{y}_i||^2-\frac{\hat{\mathbf{y}}_{i}^{T}\mathbf{y}_i ||\mathbf{y}_i||}{||\hat{\mathbf{y}}_i||} \right)
 	\end{align*}
 
-Weighting the error by the squared length of the vector effectively calculates the squared error between :math:`\mathbf{y}_i` and the prediction scaled to the amplitude of the data (:math:`\mathbf{v}_k\,||\mathbf{y}_i||`). For simplicity, we replace :math:`\mathbf{v}_k` by :math:`\mathbf{v}_i` to represent the predicted mean direction for voxel :math:`i` (already normalized to unit length). Therefore, :math:`1-R^2` between :math:`\mathbf{y}_i` and the prediction scaled to the amplitude of the data (:math:`\mathbf{v}_i\,||\mathbf{y}_i||`) is defined as:
+Weighting the error by the squared length of the vector effectively calculates the squared error between :math:`\mathbf{y}_i` and the prediction scaled to the amplitude of the data (:math:`\mathbf{v}_k\,||\mathbf{y}_i||`). To show this, we use :math:`\mathbf{v}_i` to denote the predicted mean direction for voxel :math:`i` , normalized to unit length. Therefore, :math:`1-R^2` between :math:`\mathbf{y}_i` and the prediction scaled to the amplitude of the data (:math:`\mathbf{v}_i\,||\mathbf{y}_i||`) is defined as:
 
 .. math::
 	\begin{align*}

--- a/docs/source/math.rst
+++ b/docs/source/math.rst
@@ -456,7 +456,7 @@ Now, we update the parameters :math:`\theta` of the von-Mises mixture in the M-s
 	\tilde{u}_{s,k} &= \sum_{i}^P\langle u_{s,i}^{(k)}\rangle_{q} J_{s,i}
 	\end{align*}
 
-2. In general, given these two estimates, we can updated the v parameter for the van-Mises Fisher distribution as follows:
+2. In general, given these two estimates, we can updated the v parameter for the von-Mises Fisher distribution as follows:
 
 .. math::
 	\begin{align*}
@@ -574,29 +574,39 @@ The Cosine Error is an evaluation criterion based on the dissimilarity between s
 	                          &= \frac{1}{P}\sum_i^P \left[ 1-\frac{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\hat{y}_i^{(k)}\Bigr)}{\sqrt{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\Bigr)^2}\sqrt{\displaystyle \sum_k^K\Bigl(\hat{y}_i^{(k)}\Bigr)^2}} \right]
     \end{align*}
 
-For each voxel :math:`i`, the reconstructed profile is normalized to length 1, i.e. :math:`||\mathbf{\hat{y}}_i||=\sum_k^K\Bigl(\hat{y}_i^{(k)}\Bigr)^2=1`. 
+For each voxel :math:`i`, the reconstructed activation profile is normalized to length 1, i.e. :math:`||\mathbf{\hat{y}}_i||=\sum_k^K\Bigl(\hat{y}_i^{(k)}\Bigr)^2=1`. 
 The cosine error can be then simplified to:
 
 .. math::
 	\begin{align*}
 	  \bar{\epsilon}_{cosine} &= \frac{1}{P}\sum_i^P \left[ 1-\frac{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\hat{y}_i^{(k)}\Bigr)}{\sqrt{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\Bigr)^2}} \right]
-	                           = \frac{1}{P}\sum_i^P \left[ 1-\frac{ \displaystyle \sum_k^K y_i^{(k)} \displaystyle \sum_k^K \hat{y}_i^{(k)}}{\sqrt{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\Bigr)^2}} \right] \\
+	                           = \frac{1}{P}\sum_i^P \left[ 1-\frac{ \displaystyle \sum_k^K y_i^{(k)} \displaystyle \sum_k^K \hat{y}_i^{(k)}}{\sqrt{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\Bigr)^2}} \right] \\\\
 							  &= \frac{1}{P}\sum_i^P \Biggl[ 1- \Biggl( \displaystyle \sum_k^K \hat{y}_i^{(k)} \Biggl) \frac{\mathbf{y}_i}{||\mathbf{y}_i||} \Biggr]
     \end{align*}
 
+For a given emission model, the recontructed profiles can be defined as :math:`\mathbf{\hat{Y}}_{test} = \mathbf{\hat{U}}_{test} \mathbf{V}^T`, where :math:`\mathbf{\hat{U}}_{test}` is the 
+predicted probabilistic parcellation from the test data, following a proposed distribution :math:`q(\mathbf{U})`, and :math:`\mathbf{V}` is the inferred mean direction of the model obtained 
+from the training data. The *expected* mean cosine error under :math:`q(\mathbf{u}_i)` can be thus expressed as:
 
+.. math::
+	\begin{align*}
+	   \langle\bar{\epsilon}_{cosine}\rangle_q = \frac{1}{P}\sum_i^P \Biggl[ 1- \Biggl( \displaystyle \sum_k^K \hat{u}_i^{(k)} \mathbf{v}_k^T \Biggl) \frac{\mathbf{y}_i}{||\mathbf{y}_i||} \Biggr]
+    \end{align*}
+
+Because the sum of the probabilities for each voxel :math:`i` across :math:`K` parcels must be 1, the equation above can be simplified to:
+
+.. math::
+	\begin{align*}
+	  \langle\bar{\epsilon}_{cosine}\rangle_q &= \frac{1}{P}\sum_i^P \Biggl[  \displaystyle \sum_k^K \hat{u}_i^{(k)} - \Biggl( \displaystyle \sum_k^K \hat{u}_i^{(k)} \mathbf{v}_k^T \Biggl) \frac{\mathbf{y}_i}{||\mathbf{y}_i||} \Biggr] \\\\
+                                              &= \frac{1}{P}\sum_i^P \sum_k^K \hat{u}_i^{(k)} \left(1-{\mathbf{v}_k}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||} \right)
+    \end{align*}
 
 One possibility is to use for each voxel the most likely predicted mean direction.
 
 .. math::
 	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P (1-{\mathbf{v}_\underset{k}{\operatorname{argmax}}}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||})
 
-where :math:`||\mathbf{y}_i||` is the length of the data at brain location :math:`i`, :math:`\mathbf{v}_\underset{k}{\operatorname{argmax}}` represents the :math:`\mathbf{v_k}` with the maximum expectation for that voxel. We then compute the mean cosine distance across all :math:`P` brain locations. We can also compute the  *expected* mean cosine distance under the :math:`q(\mathbf{u}_i)` which defined as below:
-
-.. math::
-	\langle\bar{\epsilon}_{cosine}\rangle_q = \frac{1}{P}\sum_i \sum_k \hat{u}_i^{(k)} (1-{\mathbf{v}_k}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||})
-
-where :math:`\hat{u}_i^{(k)}` is the inferred expectation on the training data using the fitted model.
+where :math:`\mathbf{v}_\underset{k}{\operatorname{argmax}}` represents the :math:`\mathbf{v_k}` with the maximum expectation for that voxel.
 
 2. The Adjusted Cosine Error
 ****************************

--- a/docs/source/math.rst
+++ b/docs/source/math.rst
@@ -600,8 +600,8 @@ Rather than calculating the **cosine error for the average prediction** of the p
 
 .. math::
 	\begin{align*}
-	\langle\bar{\epsilon}_{cosine}\rangle_q &= \frac{1}{P}\sum_i^P \left( 1-\frac{\left( \sum_k \hat{u}_i^{(k)}\mathbf{v}_k \right)^{T}\mathbf{y}_i}{||\mathbf{y}_i||} \right) \\\\
-	&= \frac{1}{P}\sum_i \sum_k \hat{u}_i^{(k)} \left( 1-{\mathbf{v}_k}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||} \right)
+	\langle\bar{\epsilon}_{cosine}\rangle_q &= \frac{1}{P}\sum_i \sum_k \hat{u}_i^{(k)} \left( 1-{\mathbf{v}_k}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||} \right)\\
+	&= \frac{1}{P}\sum_i^P \left( 1-\frac{\left( \sum_k \hat{u}_i^{(k)}\mathbf{v}_k \right)^{T}\mathbf{y}_i}{||\mathbf{y}_i||} \right)
 	\end{align*}
 
 When we compare the second line for the expected cosine error with the expression for cosine error for the average prediction, we see that the prediction term is normalized to unit length

--- a/docs/source/math.rst
+++ b/docs/source/math.rst
@@ -209,7 +209,6 @@ where C is the part of the normalized log-likelihood that does not depend on :ma
 So in this parameterization in the iid case, :math:`Z=1` and we don't need the negative step. In general, however, we cannot simply set the above derivative to zero and solve it, as the parameter :math:`\theta_w` will also have an influences on :math:`\langle u_{ik} \rangle`.
 
 
-
 Probabilistic multinomial restricted Boltzmann machine
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -561,6 +560,8 @@ Intuitively, :math:`M_{00}` and :math:`M_{11}` account for the agreement of parc
 
 Evaluation on independent test data (:math:`\mathbf{Y}_{test}`)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
 
 1. Cosine Error
 ***************

--- a/docs/source/math.rst
+++ b/docs/source/math.rst
@@ -561,7 +561,7 @@ Intuitively, :math:`M_{00}` and :math:`M_{11}` account for the agreement of parc
 Prediction error on independent test data (:math:`\mathbf{Y}_{test}`)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-One way to evaluate parcellation models is to test how well they can predict new test data. In general we have test data :math:`\mathbf{Y}_{test}`, a :math:`N \times P` matrix with *N* measurements (tasks, timepoints, features) and *P* brain locations (voxels, vertices) for each subject. :math:`\mathbf{y}_{i}` is the response profile (a N-long vector) for each brain location :math:`i`. 
+One way to evaluate parcellation models is to test how well they can predict new test data. In general we have test data :math:`\mathbf{Y}_{test}`, a :math:`N \times P` matrix with *N* measurements (tasks, timepoints) and *P* brain locations (voxels, vertices) for each subject. Therefore, :math:`\mathbf{y}_{i}` is the response profile (a N-long vector) for each brain location :math:`i`. 
 
 Because fMRI data (task activities or time series) have very different signal to noise levels across different voxels and subjects (and because the model does not necessarily predict the amplitude of responses), a natural evaluation criterion is the cosine error between predicted and observed data. 
 
@@ -604,8 +604,8 @@ Rather than calculating the **cosine error for the average prediction** of the p
 	&= \frac{1}{P}\sum_i \sum_k \hat{u}_i^{(k)} \left( 1-{\mathbf{v}_k}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||} \right)
 	\end{align*}
 
-When we compare the first expression of the expected cosine error with the expression of the cosine error for the average prediction, we can conclude that the prediction term is normalized to unit length 
-for the former (i.e. for each voxel :math:`i`, the sum across :math:`k` parcels must be 1) whereas that is not the case for the latter.
+When we compare the first expression of the expected cosine error with the expression of the cosine error for the average prediction, we conclude that the prediction term is normalized to unit length 
+for the former (i.e. for each voxel :math:`i`, the sum across :math:`k` parcels is 1) whereas that is not the case for the latter.
 
 
 Adjusted vs. non-adjusted cosine error

--- a/docs/source/math.rst
+++ b/docs/source/math.rst
@@ -570,8 +570,8 @@ The Cosine Error is an evaluation criterion based on the dissimilarity between s
 
 .. math::
 	\begin{align*}
-	  \bar{\epsilon}_{cosine} &= \frac{1}{P}\sum_i^P [1-\mathrm{cos}(\mathbf{Y}_{test}, \mathbf{\hat{Y}}_{test})] \\
-	                          &= \frac{1}{P}\sum_i^P \left[ 1-\frac{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\hat{y}_i^{(k)}\Bigr)}{\sqrt{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\Bigr)^2}\sqrt{\displaystyle \sum_k^K\Bigl(\hat{y}_i^{(k)}\Bigr)^2}} \right]
+	  \bar{\epsilon}_{cosine} &= \frac{1}{P}\sum_i^P \left[ 1-\mathrm{cos} \left(\mathbf{Y}_{test}, \mathbf{\hat{Y}}_{test} \right) \right] \\
+	                          &= \frac{1}{P}\sum_i^P \left[ 1-\frac{ \displaystyle \sum_k^K \left( y_i^{(k)}\hat{y}_i^{(k)}\right)}{\sqrt{ \displaystyle \sum_k^K\left(y_i^{(k)} \right)^2}\sqrt{\displaystyle \sum_k^K\left(\hat{y}_i^{(k)}\right)^2}} \right]
     \end{align*}
 
 For each voxel :math:`i`, the reconstructed activation profile is normalized to length 1, i.e. :math:`||\mathbf{\hat{y}}_i||=\sum_k^K\Bigl(\hat{y}_i^{(k)}\Bigr)^2=1`. 
@@ -604,24 +604,30 @@ Because the sum of the probabilities for each voxel :math:`i` across :math:`K` p
 One possibility is to use for each voxel the most likely predicted mean direction.
 
 .. math::
-	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P (1-{\mathbf{v}_\underset{k}{\operatorname{argmax}}}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||})
+	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P \left( 1-{\mathbf{v}_\underset{k}{\operatorname{argmax}}}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||} \right)
 
-where :math:`\mathbf{v}_\underset{k}{\operatorname{argmax}}` represents the :math:`\mathbf{v_k}` with the maximum expectation for that voxel.
+where :math:`\mathbf{v}_\underset{k}{\operatorname{argmax}}` represents the :math:`\mathbf{v}_k` with the maximum expectation for that voxel.
 
 2. The Adjusted Cosine Error
 ****************************
 
-A possible problem with the cosine error is that voxel that have very little signal count as much as voxel with a lot of signal. To address this, we can weight each error by the squared length of the data vector:
+A possible problem with the cosine error is that voxels which have very little signal count as much as voxels with a lot of signal. To address this, we can compute the weighted arithmetic mean of 
+the cosine error across these :math:`P` voxels, where each voxel's cosine error is weighted by the squared length of the data vector:
 
 .. math::
-	\bar{\epsilon}_{Acosine} = \frac{1}{\sum_i^P ||\mathbf{y}_i||^2}\sum_i^P (||\mathbf{y}_i||^2-{\mathbf{v}_\underset{k}{\operatorname{argmax}}}^{T}\mathbf{y}_i||\mathbf{y}_i||) \label{ref1}
+	\begin{align*}
+	  \langle\bar{\epsilon}_{Acosine}\rangle_q &= \frac{\sum_i^P ||\mathbf{y}_i||^2}{\sum_i^P ||\mathbf{y}_i||^2} \left[ \sum_k^K \hat{u}_i^{(k)} \left( 1 - \frac{\mathbf{v}_k^T \mathbf{y}_i}{||\mathbf{y}_i||} \right) \right] \\\\
+	                                           &= \frac{1}{\sum_i^P ||\mathbf{y}_i||^2} \sum_i^P \sum_k^K \hat{u}_i^{(k)} \left( ||\mathbf{y}_i||^2-  \frac{\mathbf{v}_k^T\mathbf{y}_i||\mathbf{y}_i||^2} {||\mathbf{y}_i||} \right) \\\\
+											   &= \frac{1}{\sum_i^P ||\mathbf{y}_i||^2}\sum_i \sum_k^K  \hat{u}_i^{(k)} \left(||\mathbf{y}_i||^2-{\mathbf{v}_k}^{T}\mathbf{y}_i||\mathbf{y}_i|| \right)
+    \end{align*}
 
-where :math:`||\mathbf{y}_i||` is the length of the data at brain location :math:`i`, :math:`\mathbf{v}_\underset{k}{\operatorname{argmax}}` represents the :math:`\mathbf{v_k}` with the maximum expectation. We then compute the mean cosine distance across all :math:`P` brain locations. Another option is to calculate the *expected* mean cosine distance under the :math:`q(\mathbf{u}_i)` which defined as below:
+Similarly, for the special case when one uses the most likely predicted mean direction, the adjusted cosine error can be simplified to:
 
 .. math::
-	\langle\bar{\epsilon}_{Acosine}\rangle_q = \frac{1}{\sum_i^P ||\mathbf{y}_i||^2}\sum_i \sum_k  \hat{u}_i^{(k)} (||\mathbf{y}_i||^2-{\mathbf{v}_k}^{T}\mathbf{y}_i||\mathbf{y}_i||)
-
-where :math:`\hat{u}_i^{(k)}` is the inferred expectation on the training data using the fitted model.
+	\begin{align*}
+	  \bar{\epsilon}_{Acosine} &= \frac{\sum_i^P ||\mathbf{y}_i||^2}{\sum_i^P ||\mathbf{y}_i||^2} \left( 1 -  \frac{{\mathbf{v}_\underset{k}{\operatorname{argmax}}}^{T}\mathbf{y}_i}{{||y||_i}}\right) \\\\
+	                           &= \frac{1}{\sum_i^P ||\mathbf{y}_i||^2}\sum_i^P \left( ||\mathbf{y}_i||^2-{\mathbf{v}_\underset{k}{\operatorname{argmax}}}^{T}\mathbf{y}_i||\mathbf{y}_i|| \right)
+	\end{align*}
 
 Proof of the Adjusted Cosine Distance is equivalent to :math:`1-R^2`
 ********************************************************************
@@ -630,19 +636,19 @@ Weighting the error by the length of the vector effectively calculates squared e
 
 .. math::
 	\begin{align*}
-	1-R^2 &= \frac{RSS}{TSS}\\
-	&=\frac{1}{\sum_i||\mathbf{y}_i||^2}\sum_i (\mathbf{y}_i-\mathbf{v}_k||\mathbf{y}_i||)^2\\
-	&=\frac{1}{\sum_i||\mathbf{y}_i||^2}\sum_i[(\mathbf{y}_i-\mathbf{v}_k||\mathbf{y}_i||)^T(\mathbf{y}_i-\mathbf{v}_k||\mathbf{y}_i||)]\\
-	&=\frac{1}{\sum_i||\mathbf{y}_i||^2}\sum_i(\mathbf{y}_i^T\mathbf{y}_i-2\mathbf{y}_i^T\mathbf{v}_k||\mathbf{y}_i||+\mathbf{v}_k^T\mathbf{v}_k||\mathbf{y}_i||^2)\\
-	&=\frac{1}{\sum_i||\mathbf{y}_i||^2}\sum_i(||\mathbf{y}_i||^2-2\mathbf{y}_i^T\mathbf{v}_k||\mathbf{y}_i||+||\mathbf{y}_i||^2)\\
-	&=\frac{2}{\sum_i||\mathbf{y}_i||^2}\sum_i(||\mathbf{y}_i||^2-\mathbf{y}_i^T\mathbf{v}_k||\mathbf{y}_i||)
+	1-R^2 &= \frac{RSS}{TSS} \\
+	&=\frac{1}{\sum_i||\mathbf{y}_i||^2}\sum_i \left( \mathbf{y}_i-\mathbf{v}_k||\mathbf{y}_i|| \right)^2 \\
+	&=\frac{1}{\sum_i||\mathbf{y}_i||^2}\sum_i \left[ (\mathbf{y}_i-\mathbf{v}_k||\mathbf{y}_i||)^T(\mathbf{y}_i-\mathbf{v}_k||\mathbf{y}_i||) \right] \\
+	&=\frac{1}{\sum_i||\mathbf{y}_i||^2}\sum_i \left( \mathbf{y}_i^T\mathbf{y}_i-2\mathbf{y}_i^T\mathbf{v}_k||\mathbf{y}_i||+\mathbf{v}_k^T\mathbf{v}_k||\mathbf{y}_i||^2 \right) \\
+	&=\frac{1}{\sum_i||\mathbf{y}_i||^2}\sum_i \left( ||\mathbf{y}_i||^2-2\mathbf{y}_i^T\mathbf{v}_k||\mathbf{y}_i||+||\mathbf{y}_i||^2 \right) \\
+	&=\frac{2}{\sum_i||\mathbf{y}_i||^2}\sum_i \left( ||\mathbf{y}_i||^2-\mathbf{y}_i^T\mathbf{v}_k||\mathbf{y}_i|| \right)
 	\end{align*}
 
 By :math:`\bar{\epsilon}_{Acosine}`, we can see that :math:`1-R^2 = 2\bar{\epsilon}_{Acosine}`, and similarly we can easily proof below equation:
 
 .. math::
 	\begin{align*}
-	\langle\bar{\epsilon}_{MSE}\rangle_q &= \frac{1}{P}\sum_i \sum_k\hat{\mathbf{u}}_i^{(k)} (\mathbf{y}_i-\mathbf{v}_k||\mathbf{y}_i||)^2=2\langle\bar{\epsilon}_{Acosine}\rangle_q
+	\langle\bar{\epsilon}_{MSE}\rangle_q &= \frac{1}{P}\sum_i \sum_k\hat{\mathbf{u}}_i^{(k)} \left( \mathbf{y}_i-\mathbf{v}_k||\mathbf{y}_i|| \right)^2=2\langle\bar{\epsilon}_{Acosine}\rangle_q
 	\end{align*}
 
 where :math:`\hat{\mathbf{u}}_i^{(k)}` is the inferred expectation on the training data using the fitted model.

--- a/docs/source/math.rst
+++ b/docs/source/math.rst
@@ -516,12 +516,12 @@ After model fitting, we need a fair way to quantitatively compare different emis
 Comparing the true :math:`\mathbf{U}` and the inferred :math:`\hat{\mathbf{U}}`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Note that these criteria only have value for simulations, for which we have the true
+Note that these criteria only have value for simulations, for which we have the true parcellation :math:`\mathbf{U}`.
 
-1. the absolute error between :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`
+1. The absolute error between :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`
 *****************************************************************************
 
-the first evaluation criterion is to calculate the absolute error between the true parcellation :math:`\mathbf{U}` and the expected :math:`\mathbf{\hat{U}}` which inferred on the training data. It defined as,
+The first evaluation criterion is to calculate the absolute error between the true parcellation :math:`\mathbf{U}` and the expected :math:`\mathbf{\hat{U}}` which inferred on the training data. It defined as,
 
 .. math::
 	\bar{U}_{error}=\frac{\sum_i|\mathbf{u_i}-\langle \mathbf{u}_{i}\rangle_{q}|}{P}
@@ -535,7 +535,7 @@ Note, this calculation of the mean absolute error is subject to the premutation 
 2. Normalized Mutual information (NMI) between :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`
 **********************************************************************************************
 
-the second criteria is the normalized mutual information which examine the actual amount of "mutual information" between two parcellations :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`.  A NMI value closes to 0 indicate two parcellations are largely independent, while values close to 1 indicate significant agreement. It defined as:
+The second criteria is the normalized mutual information which examine the actual amount of "mutual information" between two parcellations :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`.  A NMI value closes to 0 indicate two parcellations are largely independent, while values close to 1 indicate significant agreement. It defined as:
 
 .. math::
 	NMI(\mathbf{U},\mathbf{\hat{U}})=\frac{2\sum_{i=1}^{k_\mathbf{u}}\sum_{j=1}^{k_\mathbf{\hat{u}}}\frac{|\mathbf{u}=i|\cap|\mathbf{\hat{u}}=j|}{P}\log (P\frac{||\mathbf{u}=i|\cap|\mathbf{\hat{u}}=j||}{|\mathbf{u}=i|\cdot|\mathbf{\hat{u}}=j|})}{\sum_{i=1}^{k_\mathbf{u}}\frac{|\mathbf{u}=i|}{P}\log(\frac{|\mathbf{u}=i|}{P})+\sum_{j=1}^{k_{\mathbf{\hat{u}}}}\frac{|\hat{\mathbf{u}}=j|}{P}\log(\frac{|\hat{\mathbf{u}}=j|}{P})}
@@ -549,7 +549,7 @@ Similarly, the :math:`||\mathbf{u}=i|\cap|\mathbf{\hat{u}}=j||` means the total 
 3. Adjusted rand index (ARI) between :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}`
 ************************************************************************************
 
-the third one is the commonly used adjust rand index to test how similar the two given parcellations are. It defined as:
+The third one is the commonly used adjust rand index to test how similar the two given parcellations are. It defined as:
 
 .. math::
 	ARI(\mathbf{U},\mathbf{\hat{U}})=\frac{2\times(M_{11}M_{00}-M_{10}M_{01})}{(M_{00}+M_{10})(M_{10}+M_{11})+(M_{00}+M_{01})(M_{01}+M_{11})}
@@ -562,10 +562,19 @@ Intuitively, :math:`M_{00}` and :math:`M_{11}` account for the agreement of parc
 Evaluation on independent test data (:math:`\mathbf{Y}_{test}`)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1. Cosine error
+1. Cosine Error
 ***************
 
-the first evaluation criterion based on the difference between some observed activity profiles :math:`\mathbf{Y}_{test}` and the predicted mean directions from the model  :math:`\mathbf{v}_k` given some expectation of which voxel belongs to what cluster :math:`\langle \mathbf{u}_i \rangle` . One possibility is to use for each voxel the most likely predicted mean direction.
+The Cosine Error is an evaluation criterion based on the difference between some observed activity profiles :math:`\mathbf{Y}_{test}` and the predicted mean directions from the model  
+:math:`\mathbf{v}_k` given some expectation of which voxel belongs to what cluster :math:`\langle \mathbf{u}_i \rangle` . The overall cosine error is thus defined as the arithmetic 
+mean of the cosine error across $P$ voxels as follows:
+
+
+
+
+
+
+One possibility is to use for each voxel the most likely predicted mean direction.
 
 .. math::
 	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P (1-{\mathbf{v}_\underset{k}{\operatorname{argmax}}}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||})
@@ -577,7 +586,7 @@ where :math:`||\mathbf{y}_i||` is the length of the data at brain location :math
 
 where :math:`\hat{u}_i^{(k)}` is the inferred expectation on the training data using the fitted model.
 
-2. the Adjusted Cosine error
+2. The Adjusted Cosine Error
 ****************************
 
 A possible problem with the cosine error is that voxel that have very little signal count as much as voxel with a lot of signal. To address this, we can weight each error by the squared length of the data vector:
@@ -592,7 +601,7 @@ where :math:`||\mathbf{y}_i||` is the length of the data at brain location :math
 
 where :math:`\hat{u}_i^{(k)}` is the inferred expectation on the training data using the fitted model.
 
-Proof of the adjusted cosine distance is equivalent to :math:`1-R^2`
+Proof of the Adjusted Cosine Distance is equivalent to :math:`1-R^2`
 ********************************************************************
 
 Weighting the error by the length of the vector effectively calculates squared error between :math:`\mathbf{y}_i` and the prediction scaled to the amplitude of the data (:math:`\mathbf{v}_k||\mathbf{y}_i||`). For simplicity, we use :math:`\mathbf{v}_k` to represent the most likely predicted mean direction :math:`{\mathbf{v}_\underset{k}{\operatorname{argmax}}}` for each voxel in the following proof. :math:`1-R^2` between :math:`\mathbf{y}_i` and the prediction scaled to the amplitude of the data (:math:`\mathbf{v}_k||\mathbf{y}_i||`) is defined as:

--- a/docs/source/math.rst
+++ b/docs/source/math.rst
@@ -539,7 +539,7 @@ The second criteria is the normalized mutual information which examine the actua
 .. math::
 	NMI(\mathbf{U},\mathbf{\hat{U}})=\frac{2\sum_{i=1}^{k_\mathbf{u}}\sum_{j=1}^{k_\mathbf{\hat{u}}}\frac{|\mathbf{u}=i|\cap|\mathbf{\hat{u}}=j|}{P}\log (P\frac{||\mathbf{u}=i|\cap|\mathbf{\hat{u}}=j||}{|\mathbf{u}=i|\cdot|\mathbf{\hat{u}}=j|})}{\sum_{i=1}^{k_\mathbf{u}}\frac{|\mathbf{u}=i|}{P}\log(\frac{|\mathbf{u}=i|}{P})+\sum_{j=1}^{k_{\mathbf{\hat{u}}}}\frac{|\hat{\mathbf{u}}=j|}{P}\log(\frac{|\hat{\mathbf{u}}=j|}{P})}
 
-where :math:`k_{\mathbf{u}}=\{1,2,3,...,k\}` and :math:`k_{\mathbf{\hat{u}}}=\{1,2,3,...,k\}` represents the cluster labels of :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}` respectively. The term:math:`|\mathbf{u}=i|` and :math:`|\hat{\mathbf{u}}=j|` are the number of brain locations that belongs to cluster :math:`k_\mathbf{u}=i` in parcellation :math:`\mathbf{U}` or to cluster :math:`k_\mathbf{\hat{u}}=j` in :math:`\mathbf{\hat{U}}`, in other words, the terms :math:`\frac{|\mathbf{u}=i|}{P}` and :math:`\frac{|\mathbf{\hat{u}}=j|}{P}` represents the probability that a brain location picked at random from :math:`\mathbf{U}` falls into class :math:`k_{\mathbf{u}}=i`, or from :math:`\mathbf{\hat{U}}` falls into class :math:`k_{\mathbf{\hat{u}}}=j`.
+where :math:`k_{\mathbf{u}}=\{1,2,3,...,k\}` and :math:`k_{\mathbf{\hat{u}}}=\{1,2,3,...,k\}` represents the cluster labels of :math:`\mathbf{U}` and :math:`\hat{\mathbf{U}}` respectively. The term :math:`|\mathbf{u}=i|` and :math:`|\hat{\mathbf{u}}=j|` are the number of brain locations that belongs to cluster :math:`k_\mathbf{u}=i` in parcellation :math:`\mathbf{U}` or to cluster :math:`k_\mathbf{\hat{u}}=j` in :math:`\mathbf{\hat{U}}`, in other words, the terms :math:`\frac{|\mathbf{u}=i|}{P}` and :math:`\frac{|\mathbf{\hat{u}}=j|}{P}` represents the probability that a brain location picked at random from :math:`\mathbf{U}` falls into class :math:`k_{\mathbf{u}}=i`, or from :math:`\mathbf{\hat{U}}` falls into class :math:`k_{\mathbf{\hat{u}}}=j`.
 
 Similarly, the :math:`||\mathbf{u}=i|\cap|\mathbf{\hat{u}}=j||` means the total number of a brain locations that both falls into classes :math:`k_{\mathbf{u}}=i` and :math:`k_{\mathbf{\hat{u}}}=j`. Note, the NMI calculation would not suffer from the permutation.
 
@@ -566,7 +566,7 @@ One way to evaluate parcellation models is to test how well they can predict new
 Because fMRI data (task activities or time series) have very different signal to noise levels across different voxels and subjects (and because the model does not necessarily predict the amplitude of responses), a natural evaluation criterion is the cosine error between predicted and observed data. 
 
 .. math::
-	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P (1-\frac{\hat{\mathbf{y}}_{i}^{T}\mathbf{y}_i}{||\hat{\mathbf{y}}_i||||\mathbf{y}_i||})
+	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P \left( 1-\frac{\hat{\mathbf{y}}_{i}^{T}\mathbf{y}_i}{||\hat{\mathbf{y}}_i||||\mathbf{y}_i||} \right)
 
 For deriving a prediction from a probabilistic parcellation model, we have three options: 
 
@@ -575,7 +575,7 @@ Cosine error using a hard parcellation
 A simple evaluation is to set the prediction of the model to the response profile for the most likely parcel, :math:`\mathbf{v}_{\underset{k}{\operatorname{argmax}}}`. Assuming that the predicted response profiles are already length 1, the cosine error is then:
 
 .. math::
-	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P (1-{\mathbf{v}_\underset{k}{\operatorname{argmax}}}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||})
+	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P \left( 1-{\mathbf{v}_\underset{k}{\operatorname{argmax}}}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||} \right)
 
 
 Cosine Error for the average prediction
@@ -591,7 +591,7 @@ where :math:`\hat{u}_i^{(k)}` is a probability that brain location *i* belongs t
 The entire cosine error is then: 
 
 .. math::
-	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P (1-\frac{( \sum_k \hat{u}_i^{(k)}\mathbf{v}_k)^{T}\mathbf{y}_i}{|| \sum_k \hat{u}_i^{(k)}\mathbf{v}_k||||\mathbf{y}_i||})
+	\bar{\epsilon}_{cosine} = \frac{1}{P}\sum_i^P \left( 1-\frac{ \left( \sum_k \hat{u}_i^{(k)}\mathbf{v}_k \right)^{T}\mathbf{y}_i}{|| \sum_k \hat{u}_i^{(k)}\mathbf{v}_k||\:||\mathbf{y}_i||} \right)
 
 Expected cosine error
 *********************
@@ -600,24 +600,26 @@ Rather than calculating the **cosine error for the average prediction** of the p
 
 .. math::
 	\begin{align*}
-	\langle\bar{\epsilon}_{cosine}\rangle_q &= \frac{1}{P}\sum_i \sum_k \hat{u}_i^{(k)} (1-{\mathbf{v}_k}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||})\\
-	& = \frac{1}{P}\sum_i^P (1-\frac{( \sum_k \hat{u}_i^{(k)}\mathbf{v}_k)^{T}\mathbf{y}_i}{||\mathbf{y}_i||})
+	\langle\bar{\epsilon}_{cosine}\rangle_q &= \frac{1}{P}\sum_i^P \left( 1-\frac{\left( \sum_k \hat{u}_i^{(k)}\mathbf{v}_k \right)^{T}\mathbf{y}_i}{||\mathbf{y}_i||} \right) \\\\
+	&= \frac{1}{P}\sum_i \sum_k \hat{u}_i^{(k)} \left( 1-{\mathbf{v}_k}^{T}\frac{\mathbf{y}_i}{||\mathbf{y}_i||} \right)
 	\end{align*}
 
-From the second line we can see that for the difference between the cosine error for the average prediction abd the expected cosine error differ in that the prediction is being normalized to unit length for the former, but not for the latter. 
+When we compare the first expression of the expected cosine error with the expression of the cosine error for the average prediction, we can conclude that the prediction term is normalized to unit length 
+for the former (i.e. for each voxel :math:`i`, the sum across :math:`k` parcels must be 1) whereas that is not the case for the latter.
+
 
 Adjusted vs. non-adjusted cosine error
 ************************************** 
 
-For all three types of cosine error mentioned so far, a possible problem is that voxel that have very little signal count as much as voxel with a lot of signal.To address this, we can change how we average the cosine error across different voxels. A interesting choice is to weight each error by the squared length of the data vector:
+For all three types of cosine error mentioned so far, a possible problem is that a voxel which has very little signal count as much as a voxel with a lot of signal. To address this, we can change how we average the cosine error across different voxels. An interesting choice is to weight each error by the squared length of the data vector:
 
 .. math::
 	\begin{align*}
-	\bar{\epsilon}_{Acosine} &= \frac{1}{\sum_i^P ||\mathbf{y}_i||^2} \sum_i^P ||\mathbf{y}_i||^2 (1-\frac{\hat{\mathbf{y}}_{i}^{T}\mathbf{y}_i}{||\hat{\mathbf{y}}_i||||\mathbf{y}_i||}))\\
-	&= \frac{1}{\sum_i^P ||\mathbf{y}_i||^2} \sum_i^P  (||\mathbf{y}_i||^2-\frac{\hat{\mathbf{y}}_{i}^{T}\mathbf{y}_i ||\mathbf{y}_i||}{||\hat{\mathbf{y}}_i||}))
+	\bar{\epsilon}_{Acosine} &= \frac{1}{\sum_i^P ||\mathbf{y}_i||^2} \sum_i^P ||\mathbf{y}_i||^2 \left( 1-\frac{\hat{\mathbf{y}}_{i}^{T}\mathbf{y}_i}{||\hat{\mathbf{y}}_i||\,||\mathbf{y}_i||} \right) \\\\
+	&= \frac{1}{\sum_i^P ||\mathbf{y}_i||^2} \sum_i^P  \left( ||\mathbf{y}_i||^2-\frac{\hat{\mathbf{y}}_{i}^{T}\mathbf{y}_i ||\mathbf{y}_i||}{||\hat{\mathbf{y}}_i||} \right)
 	\end{align*}
 
-Weighting the error by the squared length of the vector effectively calculates squared error between :math:`\mathbf{y}_i` and the prediction scaled to the amplitude of the data (:math:`\mathbf{v}_k||\mathbf{y}_i||`). For simplicity, we use :math:`\mathbf{v}_i` to represent the predicted mean direction for this voxel (already normalized to unit length). :math:`1-R^2` between :math:`\mathbf{y}_i` and the prediction scaled to the amplitude of the data (:math:`\mathbf{v}_i||\mathbf{y}_i||`) is defined as:
+Weighting the error by the squared length of the vector effectively calculates the squared error between :math:`\mathbf{y}_i` and the prediction scaled to the amplitude of the data (:math:`\mathbf{v}_k\,||\mathbf{y}_i||`). For simplicity, we replace :math:`\mathbf{v}_k` by :math:`\mathbf{v}_i` to represent the predicted mean direction for voxel :math:`i` (already normalized to unit length). Therefore, :math:`1-R^2` between :math:`\mathbf{y}_i` and the prediction scaled to the amplitude of the data (:math:`\mathbf{v}_i\,||\mathbf{y}_i||`) is defined as:
 
 .. math::
 	\begin{align*}
@@ -629,4 +631,4 @@ Weighting the error by the squared length of the vector effectively calculates s
 	&=\frac{2}{\sum_i||\mathbf{y}_i||^2}\sum_i(||\mathbf{y}_i||^2-\mathbf{y}_i^T\mathbf{v}_i||\mathbf{y}_i||)
 	\end{align*}
 
-Adjusting for the length of the data vector can be done for any of the previously mentioned types of cosine error: The hard cosine error, the cosine error for the average prediction, and the expected cosine error.
+Adjusting for the length of the data vector can be done for any of the previously mentioned types of cosine error, i.e. for the hard-parcellation cosine error, the cosine error for the average prediction, and the expected cosine error.

--- a/docs/source/math.rst
+++ b/docs/source/math.rst
@@ -565,12 +565,24 @@ Evaluation on independent test data (:math:`\mathbf{Y}_{test}`)
 1. Cosine Error
 ***************
 
-The Cosine Error is an evaluation criterion based on the difference between some observed activity profiles :math:`\mathbf{Y}_{test}` and the predicted mean directions from the model  
-:math:`\mathbf{v}_k` given some expectation of which voxel belongs to what cluster :math:`\langle \mathbf{u}_i \rangle` . The overall cosine error is thus defined as the arithmetic 
-mean of the cosine error across $P$ voxels as follows:
+The Cosine Error is an evaluation criterion based on the dissimilarity between some observed activation profiles :math:`\mathbf{Y}_{test}` across :math:`P` voxels and reconstructed profiles 
+:math:`\mathbf{\hat{Y}}_{test}` from a model defined along :math:`K` parcels, with :math:`K \ll P`. The overall cosine error is thus defined as the arithmetic mean of the cosine error across voxels.
 
+.. math::
+	\begin{align*}
+	  \bar{\epsilon}_{cosine} &= \frac{1}{P}\sum_i^P [1-\mathrm{cos}(\mathbf{Y}_{test}, \mathbf{\hat{Y}}_{test})] \\
+	                          &= \frac{1}{P}\sum_i^P \left[ 1-\frac{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\hat{y}_i^{(k)}\Bigr)}{\sqrt{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\Bigr)^2}\sqrt{\displaystyle \sum_k^K\Bigl(\hat{y}_i^{(k)}\Bigr)^2}} \right]
+    \end{align*}
 
+For each voxel :math:`i`, the reconstructed profile is normalized to length 1, i.e. :math:`||\mathbf{\hat{y}}_i||=\sum_k^K\Bigl(\hat{y}_i^{(k)}\Bigr)^2=1`. 
+The cosine error can be then simplified to:
 
+.. math::
+	\begin{align*}
+	  \bar{\epsilon}_{cosine} &= \frac{1}{P}\sum_i^P \left[ 1-\frac{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\hat{y}_i^{(k)}\Bigr)}{\sqrt{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\Bigr)^2}} \right]
+	                           = \frac{1}{P}\sum_i^P \left[ 1-\frac{ \displaystyle \sum_k^K y_i^{(k)} \displaystyle \sum_k^K \hat{y}_i^{(k)}}{\sqrt{ \displaystyle \sum_k^K\Bigl(y_i^{(k)}\Bigr)^2}} \right] \\
+							  &= \frac{1}{P}\sum_i^P \Biggl[ 1- \Biggl( \displaystyle \sum_k^K \hat{y}_i^{(k)} \Biggl) \frac{\mathbf{y}_i}{||\mathbf{y}_i||} \Biggr]
+    \end{align*}
 
 
 

--- a/examples/atlas_training_example.ipynb
+++ b/examples/atlas_training_example.ipynb
@@ -30,10 +30,10 @@
     "import matplotlib.pyplot as plt\n",
     "import Functional_Fusion.atlas_map as am\n",
     "import Functional_Fusion.dataset as ds\n",
-    "import HierarchBayesParcel.HierarchBayesParcel.arrangements as ar\n",
-    "import HierarchBayesParcel.HierarchBayesParcel.emissions as em\n",
-    "import HierarchBayesParcel.HierarchBayesParcel.full_model as fm\n",
-    "import HierarchBayesParcel.HierarchBayesParcel.util as ut\n",
+    "import HierarchBayesParcel.arrangements as ar\n",
+    "import HierarchBayesParcel.emissions as em\n",
+    "import HierarchBayesParcel.full_model as fm\n",
+    "import HierarchBayesParcel.util as ut\n",
     "import SUITPy as suit"
    ]
   },
@@ -548,7 +548,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -562,7 +562,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/examples/individual_parcellation_example.ipynb
+++ b/examples/individual_parcellation_example.ipynb
@@ -28,10 +28,10 @@
     "import matplotlib.pyplot as plt\n",
     "import Functional_Fusion.atlas_map as am\n",
     "import Functional_Fusion.dataset as ds\n",
-    "import HierarchBayesParcel.HierarchBayesParcel.arrangements as ar\n",
-    "import HierarchBayesParcel.HierarchBayesParcel.emissions as em\n",
-    "import HierarchBayesParcel.HierarchBayesParcel.full_model as fm\n",
-    "import HierarchBayesParcel.HierarchBayesParcel.util as ut\n",
+    "import HierarchBayesParcel.arrangements as ar\n",
+    "import HierarchBayesParcel.emissions as em\n",
+    "import HierarchBayesParcel.full_model as fm\n",
+    "import HierarchBayesParcel.util as ut\n",
     "import SUITPy as suit\n"
    ]
   },
@@ -267,7 +267,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -281,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Development of cosine-error derivation under the HBP framework. The PR also includes some typo fixes and editing improvements of the entire "Mathematical Details" page. @jdiedrichsen 